### PR TITLE
Added LIBRARY_PATH to the CMake's library path for the NVDec backend.

### DIFF
--- a/tvl_backends/tvl-backends-nvdec/ext/CMakeLists.txt
+++ b/tvl_backends/tvl-backends-nvdec/ext/CMakeLists.txt
@@ -5,6 +5,10 @@ add_library(tvlnv
     nvidia/MemManager.cpp
 )
 
+# NVIDIA Docker images add the CUDA stub library directory to the environment variable
+# "LIBRARY_PATH". Here we make CMake aware of this.
+list(APPEND CMAKE_SYSTEM_LIBRARY_PATH $ENV{LIBRARY_PATH})
+
 # TODO: Error message upon fail to find
 find_library(CUDA_LIBRARY cuda)
 find_path(AVCODEC_INCLUDE_DIR libavcodec/avcodec.h)


### PR DESCRIPTION
This is the same addition made to the fffr backend's CMake file.

This allowed me to build the tvl docker image.