### PR TITLE
FFFR: Improve memory usage.

### DIFF
--- a/tvl_backends/tvl-backends-fffr/ext/bindings/TvFFFrameReader.cpp
+++ b/tvl_backends/tvl-backends-fffr/ext/bindings/TvFFFrameReader.cpp
@@ -175,39 +175,36 @@ uint8_t* TvFFFrameReader::read_frame()
 
 int64_t TvFFFrameReader::read_frames_by_index(int64_t* indices, const int n_frames, uint8_t** frames)
 {
-    int32_t block_size = 8;
-    for (int32_t pos = 0; pos < n_frames;) {
+    int32_t pos = 0;
+    while (pos < n_frames) {
         const auto start = &indices[pos];
-        const auto last = pos + block_size;
+        const auto last = pos + static_cast<int32_t>(_stream->getMaxFrames());
         const auto end = &indices[std::min(last, n_frames)];
         const std::vector<int64_t> frame_sequence(start, end);
         const auto frames_vector = _stream->getFramesByIndex(frame_sequence);
-        int32_t n_frames_read = frames_vector.size();
-        // If the actual number of frames decoded is less than the number of frames that we
-        // requested, reduce the number of frames that we request next time and ignore the last
-        // frame returned (it might be wrong).
-        if (n_frames_read < frame_sequence.size()) {
-            block_size = n_frames_read;
-            --n_frames_read;
-        }
         // Convert the pixel format of the decoded frames.
-        for (int i = 0; i < n_frames_read; ++i) {
-            *(frames++) = convert_frame(frames_vector.at(i), true);
+        for (auto& i : frames_vector) {
+            *(frames++) = convert_frame(i, true);
         }
-        if (_stream->getDecodeType() == Ffr::DecodeType::Cuda) {
-            if (!Ffr::synchroniseConvert(_stream)) {
-                throw std::runtime_error("Pixel format conversion failed.");
-            }
-        }
-        if (n_frames_read == 0) {
+        if (frames_vector.size() == 0) {
             if (_stream->isEndOfFile()) {
+                if (_stream->getDecodeType() == Ffr::DecodeType::Cuda) {
+                    if (!Ffr::synchroniseConvert(_stream)) {
+                        throw std::runtime_error("Pixel format conversion failed.");
+                    }
+                }
                 // Return false to indicate "end of file".
                 return false;
             }
             throw std::runtime_error("Failed to get the next frame sequence.");
         }
         // Advance our position within the array of frame indices.
-        pos += n_frames_read;
+        pos += static_cast<int32_t>(frames_vector.size());
     }
-    return n_frames;
+    if (_stream->getDecodeType() == Ffr::DecodeType::Cuda) {
+        if (!Ffr::synchroniseConvert(_stream)) {
+            throw std::runtime_error("Pixel format conversion failed.");
+        }
+    }
+    return pos;
 }


### PR DESCRIPTION
getFramesByIndex now guarantees that bufferLength frames are returned so there is no need to change block_size as now it should be the same as bufferLength as that parameter effects both. 

A larger bufferLength can slightly improve performance by allowing for larger batch sizes but also increases memory usage due to more inflight frames so currently its set to 1 (can be played with if desired).