### PR TITLE
[WIP] Cupy integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN cd /tmp \
  && git clone --branch n9.0.18.1 --single-branch --depth 1 \
     https://git.videolan.org/git/ffmpeg/nv-codec-headers.git \
  && cd nv-codec-headers \
- && make && make install \
+ && make -j$(nproc) && make install \
  && rm -rf /tmp/nv-codec-headers
 
 # Build FFmpeg, enabling only selected features
@@ -33,7 +33,7 @@ RUN cd /tmp && curl -sLO http://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.b
     --disable-iconv \
     --disable-doc \
     --disable-ffplay \
- && make -j8 \
+ && make -j$(nproc) \
  && checkinstall -y --nodoc --install=no \
  && mv ffmpeg_$FFMPEG_VERSION-1_amd64.deb /ffmpeg.deb \
  && cd /tmp && rm -rf ffmpeg-$FFMPEG_VERSION
@@ -84,7 +84,7 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY . /app
-RUN make dist
+RUN make dist -j$(nproc)
 
 
 ################################################################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,7 @@ RUN apt-get update \
 COPY requirements.txt /app
 RUN pip3 install -r requirements.txt
 
+RUN pip3 install --upgrade cupy-cuda112
 
 # Install tvl
 COPY --from=tvl-builder /app/dist/tvl*.whl /tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,9 +135,6 @@ RUN pip3 install --upgrade cupy-cuda112
 COPY --from=tvl-builder /app/dist/tvl*.whl /tmp/
 RUN pip3 install -f /tmp \
     tvl \
-    tvl-backends-nvdec \
-    tvl-backends-opencv \
-    tvl-backends-pyav \
     tvl-backends-fffr \
   && rm /tmp/tvl*.whl
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
-FROM nvidia/cuda:10.0-devel-ubuntu18.04 as ffmpeg-builder
+FROM nvcr.io/nvidia/cuda:11.2.2-devel-ubuntu20.04 as ffmpeg-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Paris
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
 
 # https://github.com/NVIDIA/nvidia-docker/issues/969
 RUN rm /etc/apt/sources.list.d/nvidia-ml.list
@@ -37,30 +42,20 @@ RUN cd /tmp && curl -sLO http://ffmpeg.org/releases/ffmpeg-$FFMPEG_VERSION.tar.b
 ################################################################################
 
 
-FROM nvidia/cuda:10.0-devel-ubuntu18.04 as tvl-builder
+FROM nvcr.io/nvidia/cuda:11.2.2-devel-ubuntu20.04 as tvl-builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Paris
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
 
 # https://github.com/NVIDIA/nvidia-docker/issues/969
 RUN rm /etc/apt/sources.list.d/nvidia-ml.list
 
 RUN apt-get update \
- && apt-get install -y curl git \
+ && apt-get install -y curl git swig python3.8-dev python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Miniconda and Python 3.6.5
-ENV CONDA_AUTO_UPDATE_CONDA=false
-ENV PATH=/root/miniconda/bin:$PATH
-RUN curl -sLo ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh \
- && chmod +x ~/miniconda.sh \
- && ~/miniconda.sh -b -p ~/miniconda \
- && rm ~/miniconda.sh \
- && conda install -y python==3.6.5 \
- && conda clean -ya
-
-# Install PyTorch with CUDA support
-RUN conda install -y -c pytorch \
-    cudatoolkit=10.0 \
-    "pytorch=1.1.0=py3.6_cuda10.0.130_cudnn7.5.1_0" \
- && conda clean -ya
 
 RUN apt-get update \
  && apt-get install -y pkg-config \
@@ -70,8 +65,6 @@ RUN apt-get update \
 COPY --from=ffmpeg-builder /ffmpeg.deb /tmp/ffmpeg.deb
 RUN dpkg -i /tmp/ffmpeg.deb && rm /tmp/ffmpeg.deb
 
-# Install Swig
-RUN conda install -y swig=3.0.12 && conda clean -ya
 
 # Add a stub version of libnvcuvid.so for building (required for CUDA backends).
 # This library is provided by nvidia-docker at runtime when the environment variable
@@ -82,10 +75,10 @@ RUN curl -sLo /usr/lib/x86_64-linux-gnu/libnvcuvid.so.1 \
  && ln -s libnvcuvid.so.1 /usr/lib/x86_64-linux-gnu/libnvcuvid.so
 
 # Install CMake
-RUN pip install cmake==3.13.3
+RUN pip3 install cmake==3.18.4
 
 # Install scikit-build
-RUN pip install scikit-build==0.10.0
+RUN pip3 install scikit-build==0.10.0
 
 RUN mkdir /app
 WORKDIR /app
@@ -96,8 +89,12 @@ RUN make dist
 
 ################################################################################
 
+FROM nvcr.io/nvidia/cuda:11.2.2-devel-ubuntu20.04
 
-FROM nvidia/cuda:10.0-devel-ubuntu18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Europe/Paris
+ENV NVIDIA_DRIVER_CAPABILITIES=all
 
 # https://github.com/NVIDIA/nvidia-docker/issues/969
 RUN rm /etc/apt/sources.list.d/nvidia-ml.list
@@ -106,21 +103,7 @@ RUN apt-get update \
  && apt-get install -y curl git \
  && rm -rf /var/lib/apt/lists/*
 
-# Install Miniconda and Python 3.6.5
-ENV CONDA_AUTO_UPDATE_CONDA=false
-ENV PATH=/root/miniconda/bin:$PATH
-RUN curl -sLo ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-4.5.4-Linux-x86_64.sh \
- && chmod +x ~/miniconda.sh \
- && ~/miniconda.sh -b -p ~/miniconda \
- && rm ~/miniconda.sh \
- && conda install -y python==3.6.5 \
- && conda clean -ya
 
-# Install PyTorch with CUDA support
-RUN conda install -y -c pytorch \
-    cudatoolkit=10.0 \
-    "pytorch=1.1.0=py3.6_cuda10.0.130_cudnn7.5.1_0" \
- && conda clean -ya
 
 RUN apt-get update \
  && apt-get install -y pkg-config \
@@ -140,15 +123,16 @@ WORKDIR /app
 
 # Install OpenCV dependencies
 RUN apt-get update \
- && apt-get install -y libsm6 libxext6 libxrender1 \
+ && apt-get install -y libsm6 libxext6 libxrender1 python3.8-dev python3-pip \
  && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /app
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
+
 
 # Install tvl
 COPY --from=tvl-builder /app/dist/tvl*.whl /tmp/
-RUN pip install -f /tmp \
+RUN pip3 install -f /tmp \
     tvl \
     tvl-backends-nvdec \
     tvl-backends-opencv \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL	:= /bin/bash
-PYTHON	?= python
+PYTHON	?= python3.8
 SETUP	:= setup.py
 
 SUBDIRS := $(wildcard tvl_backends/tvl-backends-*)
@@ -39,7 +39,7 @@ install-dev:
 	for dir in $(SUBDIRS); do \
 		pushd $$dir && pip install -e . && popd || exit 1; \
 		if [ -d "$$dir/_skbuild" ]; then \
-			ln -sfn "$(PWD)/$$dir/_skbuild/linux-x86_64-3.6/cmake-install/lib/python3.6/site-packages/"* "$(PY_PKG_DIR)/"; \
+			ln -sfn "$(PWD)/$$dir/_skbuild/linux-x86_64-3.8/cmake-install/lib/python3.8/site-packages/"* "$(PY_PKG_DIR)/"; \
 		fi \
 	done
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 hypothesis==4.10.0
-numpy==1.16.2
+numpy==1.20.1
 Pillow==6.2.2
-torch==1.1.0
+torch==1.7.1
+torchvision==0.8.2
 torchgeometry==0.1.2
-
-pytest==4.4.0
-pytest-mock==1.10.1
-pytest-xdist==1.28.0
+pytest==6.2.2
+pytest-mock==3.5.1
+pytest-xdist==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,25 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-version = Path(__file__).absolute().parent.joinpath('VERSION').read_text('utf-8').strip()
+version = (
+    Path(__file__).absolute().parent.joinpath("VERSION").read_text("utf-8").strip()
+)
 
 
 setup(
-    name='tvl',
+    name="tvl",
     version=version,
-    author='Aiden Nibali',
-    license='Apache Software License 2.0',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
+    author="Aiden Nibali",
+    license="Apache Software License 2.0",
+    packages=find_packages("src"),
+    package_dir={"": "src"},
     include_package_data=True,
     install_requires=[
-        'numpy',
-        'torch',
-        'torchgeometry>=0.1.2',
+        "numpy",
+        "torch",
+        "torchgeometry>=0.1.2",
     ],
     extras_require={
         'FffrBackend': ['tvl-backends-fffr==' + version],
-        'NvdecBackend': ['tvl-backends-nvdec==' + version],
-        'PyAvBackend': ['tvl-backends-pyav==' + version],
-        'OpenCvBackend': ['tvl-backends-opencv==' + version],
     },
 )

--- a/tvl_backends/tvl-backends-fffr/src/tvl_backends/fffr/memory.py
+++ b/tvl_backends/tvl-backends-fffr/src/tvl_backends/fffr/memory.py
@@ -2,6 +2,7 @@ import warnings
 
 import pyfffr
 import torch
+import cupy
 
 
 def _dtype_bytes(dtype):
@@ -15,12 +16,9 @@ def _align(value, alignment):
     return ((value - 1) // alignment + 1) * alignment
 
 
-class TorchImageAllocator(pyfffr.ImageAllocator):
-    def __init__(self, device, dtype):
+class CupyImageAllocator(pyfffr.ImageAllocator):
+    def __init__(self, dtype):
         super().__init__()
-        if isinstance(device, str):
-            device = torch.device(device)
-        self.device = device
         self.dtype = dtype
         self.tensors = {}
 
@@ -39,8 +37,8 @@ class TorchImageAllocator(pyfffr.ImageAllocator):
         Returns:
             Address of the allocated memory.
         """
-        elem_size = _dtype_bytes(self.dtype)  # Size of a pixel channel element.
         assert alignment % elem_size == 0, 'alignment must be a multiple of element size'
+        elem_size = 1
 
         # Align the line size.
         line_size = _align(line_size, alignment)
@@ -50,21 +48,18 @@ class TorchImageAllocator(pyfffr.ImageAllocator):
         align_elems = alignment // elem_size
 
         # Allocate memory with extra space for starting pointer alignment.
-        n_padded_elems = 3 * (height * line_elems) + align_elems
-        storage = torch.empty(n_padded_elems, device=self.device, dtype=self.dtype).storage()
+        n_padded_elems = 3 * (height * line_elems)
+        storage = cupy.empty(n_padded_elems, dtype=self.dtype)
+        ptr = storage.data.ptr
 
         # Calculate memory offset and stride.
-        ptr = storage.data_ptr()
         aligned_ptr = _align(ptr, alignment)
         assert (aligned_ptr - ptr) % elem_size == 0
         storage_offset = (aligned_ptr - ptr) // elem_size
         plane_stride = height * line_elems
 
         # Create a tensor for viewing the allocated memory.
-        tensor = torch.empty((0,), device=self.device, dtype=self.dtype)
-        tensor.set_(storage, storage_offset=storage_offset, size=(3, height, width),
-                    stride=(plane_stride, line_elems, 1))
-        self.tensors[ptr] = tensor
+        self.tensors[ptr] = storage.reshape(3, height, width)
 
         return ptr
 
@@ -75,19 +70,14 @@ class TorchImageAllocator(pyfffr.ImageAllocator):
             warnings.warn('Skipped an attempt to free unrecognised memory.')
 
     def get_data_type(self):
-        if self.dtype == torch.uint8:
+        if self.dtype == cupy.uint8:
             return pyfffr.ImageAllocator.UINT8
-        if self.dtype == torch.float32:
+        if self.dtype == cupy.float32:
             return pyfffr.ImageAllocator.FLOAT32
-        raise Exception(f'unsupported dtype: {self.dtype}')
+        raise Exception(f"unsupported dtype: {self.dtype}")
 
     def get_device_index(self):
-        if self.device.type == 'cuda':
-            if self.device.index is None:
-                return torch.cuda.current_device()
-            else:
-                return self.device.index
-        return -1
+        return 0
 
     def get_frame_tensor(self, address):
         return self.tensors[address]

--- a/tvl_backends/tvl-backends-nvdec/ext/nvidia/NvDecoder/NvDecoder.h
+++ b/tvl_backends/tvl-backends-nvdec/ext/nvidia/NvDecoder/NvDecoder.h
@@ -127,7 +127,7 @@ public:
     /**
     *   @brief  This function is used to get the current frame size based on pixel format.
     */
-    int GetFrameSize() { assert(m_nWidth); return m_nWidth * m_nHeight * 3 / (m_nBitDepthMinus8 ? 1 : 2); }
+    int GetFrameSize() { assert(m_nWidth); return m_nWidth * m_nHeight * 3; }
 
     /**
     *  @brief  This function is used to get the pitch of the device buffer holding the decoded frame.
@@ -202,7 +202,7 @@ private:
     int HandlePictureDecode(CUVIDPICPARAMS *pPicParams);
 
     /**
-    *   @brief  This function gets called after a picture is decoded and available for display. Frames are fetched and stored in 
+    *   @brief  This function gets called after a picture is decoded and available for display. Frames are fetched and stored in
         internal buffer
     */
     int HandlePictureDisplay(CUVIDPARSERDISPINFO *pDispInfo);
@@ -224,7 +224,7 @@ private:
     CUvideodecoder m_hDecoder = NULL;
     // dimension of the output
     unsigned int m_nWidth = 0, m_nHeight = 0;
-    // height of the mapped surface 
+    // height of the mapped surface
     int m_nSurfaceHeight = 0;
     int m_nSurfaceWidth = 0;
     cudaVideoChromaFormat m_eChromaFormat;
@@ -232,7 +232,7 @@ private:
     CUVIDEOFORMAT m_videoFormat = {};
     Rect m_displayRect = {};
     // stock of frames
-    std::vector<uint8_t *> m_vpFrame; 
+    std::vector<uint8_t *> m_vpFrame;
     // decoded frames for return
     std::vector<uint8_t *> m_vpFrameRet;
     // timestamps of decoded frames

--- a/tvl_backends/tvl-backends-nvdec/src/tvl_backends/nvdec/__init__.py
+++ b/tvl_backends/tvl-backends-nvdec/src/tvl_backends/nvdec/__init__.py
@@ -1,81 +1,74 @@
 from functools import lru_cache
 
-import torch
+import cupy
 
 import tvlnv
 from tvl.backend import Backend, BackendFactory
 
 
-class TorchMemManager(tvlnv.MemManager):
-    """MemManager implementation which allocates Torch tensors."""
+class CupyMemManager(tvlnv.MemManager):
+    """MemManager implementation which allocates cupy arrays."""
 
-    def __init__(self, device):
+    def __init__(self):
         super().__init__()
-        self.device = device
         self.tensors = {}
 
     def clear(self):
         self.tensors.clear()
 
     def get_mem_type(self):
-        if self.device.type == 'cuda':
-            return tvlnv.MEM_TYPE_CUDA
-        return tvlnv.MEM_TYPE_HOST
+        return tvlnv.MEM_TYPE_CUDA
 
     def allocate(self, size):
-        tensor = torch.empty(size, dtype=torch.uint8, device=self.device)
-        ptr = tensor.data_ptr()
+        tensor = cupy.empty(size, dtype=cupy.uint8)
+        ptr = tensor.__cuda_array_interface__["data"][0]
         self.tensors[ptr] = tensor
         return ptr
-
-
-@lru_cache(8)
-def _nv12_conv_consts(device):
-    const1 = torch.tensor([6.258931e-3, -1.536320e-3, 7.910723e-3], device=device).view(3, 1, 1)
-    const2 = torch.tensor([-0.8742, 0.5316706, -1.0856313], device=device).view(3, 1, 1)
-    return const1, const2
 
 
 def nv12_to_rgb(planar_yuv, h, w):
     """Converts planar YUV pixel data in NV12 format to RGB.
 
     Args:
-        planar_yuv (torch.ByteTensor): Planar YUV pixels in [0, 255] value range.
+        planar_yuv (cupy.array): Planar YUV pixels in [0, 255] value range.
         h: Height of the image.
         w: Width of the image.
 
     Returns:
-        torch.FloatTensor: RGB pixels in [0, 1] value range.
+        cupy.array: RGB pixels in [0, 255] value range.
     """
-    rgb = torch.empty([3, h, w], dtype=torch.float32, device=planar_yuv.device)
-    # Memory reuse trick
-    v, _, u = rgb
-    # Extract luma channel
-    y = planar_yuv[:w*h].view(h, w).float()
-    # Extract and upsample chroma channels
-    u.copy_(planar_yuv[w*h::2].view(h//2, 1, w//2, 1).expand(h//2, 2, w//2, 2).contiguous().view(h, w))
-    v.copy_(planar_yuv[w*h+1::2].view(h//2, 1, w//2, 1).expand(h//2, 2, w//2, 2).contiguous().view(h, w))
-    # YUV [0, 255] to RGB [0, 1]
-    torch.add(u, 2.075161, v, out=rgb[1])
-    const1, const2 = _nv12_conv_consts(str(rgb.device))
-    rgb.mul_(const1)
-    torch.add(rgb, 4.566207e-3, y, out=rgb)
-    rgb.add_(const2)
+    print(planar_yuv.shape)
+    y = planar_yuv[: w * h].reshape(h, w, -1)
+    u = planar_yuv[w * h : 2 * (w * h)].reshape(h, w, -1)
+    v = planar_yuv[2 * (w * h) :].reshape(h, w, -1)
+    y -= 16
+    u -= 128
+    v -= 128
+    rgb = cupy.concatenate(
+        (
+            1.164 * y + 1.596 * v,
+            1.164 * y - 0.392 * u - 0.813 * v,
+            1.164 * y + 2.017 * u,
+        ),
+        -1,
+    ).astype(cupy.uint8)
 
-    return rgb.clamp_(0, 1)
+    return rgb
 
 
 class NvdecBackend(Backend):
-    def __init__(self, filename, device, dtype, *, seek_threshold=3, out_width=0, out_height=0):
+    def __init__(
+        self, filename, device, dtype, *, seek_threshold=3, out_width=0, out_height=0
+    ):
         super().__init__(filename, device, dtype, seek_threshold, out_width, out_height)
-        assert self.device.type == 'cuda'
-        mem_manager = TorchMemManager(self.device)
+        mem_manager = CupyMemManager()
         # Disown mem_manager, since TvlnvFrameReader will be responsible for deleting it.
         mem_manager = mem_manager.__disown__()
 
         self.mem_manager = mem_manager
-        self.frame_reader = tvlnv.TvlnvFrameReader(mem_manager, self.filename, self.device.index,
-                                                   out_width, out_height)
+        self.frame_reader = tvlnv.TvlnvFrameReader(
+            mem_manager, self.filename, 0, out_width, out_height
+        )
 
     @property
     def duration(self):


### PR DESCRIPTION
I did this to change torch tensor storage of decoded frames to cupy.

This is because the memory footprint of cupy is much lower than pytorch. Since I plan on using this in a multiprocessed env, I needed the footprint on the GPU per process to be low. This should allow me to use ~70 processes on a 16GB VRAM GPU, which is much better than about 15 with pytorch.

I wasn't really planning on merging this, and doing the work to allow for storage nature choice with a flag or whatever. I planned on just making it run for my specific use in particular (hence many deleted functionnalities). But I think it's still good that people coming here know that cupy integration is possible.

Also I tried jax, but the imutable nature of the jax arrays prevented me from doing anything.

Note that torch / cupy interoperability is alive and well.